### PR TITLE
$(GENHEADERS) in bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 
 PYFILES = genheaders.py reg.py
 GENOPTS =
-GENHEADERS = genheaders.py $(GENOPTS)
+GENHEADERS = ./genheaders.py $(GENOPTS)
 
 # Generate all headers for GL / GLES / WGL / GLX / EGL
 # Different headers depend on different XML registry files


### PR DESCRIPTION
On my system I needed to do ./genheaders.py rather than genheaders.py for the build to work. Otherwise the whole gl-rs wouldn't build.

Are there any problems with the change?
